### PR TITLE
fix: 色々遊んでみた（コマンドを複数行で実行、 name の使用、手動実行ワークフローと引数 inputs の実験）

### DIFF
--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -4,6 +4,9 @@ jobs:
   hello:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
       - name: Run script
         run: |
           echo "Hello, world"

--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -4,5 +4,9 @@ jobs:
   hello:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Hello, world"
+      - run: |
+        echo "Hello, world"
+        echo 2
+        git log -1
+        tree -a .
       - uses: actions/checkout@v4

--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -4,9 +4,11 @@ jobs:
   hello:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-        echo "Hello, world"
-        echo 2
-        git log -1
-        tree -a .
-      - uses: actions/checkout@v4
+      - name: Run script
+        run: |
+          echo "Hello, world"
+          echo 2
+          git log -1
+          tree -a .
+      - name: Checkout repository
+        uses: actions/checkout@v4

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,14 @@
+name: Manual
+on:
+  workflow_dispatch:                       # 手動実行イベント
+    inputs:
+      greeting:                            # 入力パラメータ名
+        type: string                       # データ型（文字列）
+        default: Hello                     # 入力パラメータのデフォルト値
+        required: true                     # 入力パラメータの必須フラグ
+        description: A cheerful word       # 入力パラメータの概要
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ inputs.greeting }}" # 入力パラメータ「greeting」の参照


### PR DESCRIPTION
このステップの数だけログが分割されるのね。
- https://github.com/ittyi/pracGitHubActions/actions/runs/12213862259/job/34073950623?pr=2
<img width="937" alt="スクリーンショット 2024-12-08 0 02 55" src="https://github.com/user-attachments/assets/7ceda43a-44f5-4236-98d7-eee6bb0f193c">

弊社の Actions も、もっとサービス単位でテスト分けられるんじゃないか。その方が見やすそう


## gh run view はリポジトリ内で行う必要がある。.git で制御してるのかしら。
```sh
gh run view                                                   
failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
```
    